### PR TITLE
auto import時に既存のimport分の「i」が削除されるのを対処

### DIFF
--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -103,7 +103,7 @@ async function transformComponent(
 			return item
 		})
 
-		s.overwrite(index, index + 1, `\n ${imports.join("\n")} \n`)
+		s.appendLeft(index, `\n ${imports.join("\n")} \n`)
 	} else {
 		const script = `<script>${imports.join("\n")}</script>`
 


### PR DESCRIPTION
```
 Plugin: vite-plugin-svelte
  File: /Users/furutsubaki/dev/pengest/src/routes/+error.svelte
   
   Expected ";" but found "{"
   3  |   import H1 from "$lib/components/headding/H1.svelte"
   4  |  import H2 from "$lib/components/headding/H2.svelte"
   5  |  mport { browser } from '$app/environment';
      |        ^
   6  |  import { onMount, onDestroy } from 'svelte';
```

`mport { browser } from '$app/environment';` deleted `i` fix