### PR TITLE
存在チェックでダブルクォートからシングルクォートへの変換がなく一致が見つからなかったのを修正

### DIFF
--- a/src/core/transformer.ts
+++ b/src/core/transformer.ts
@@ -97,7 +97,7 @@ async function transformComponent(
 
 		imports = imports.filter((item) => {
 			const exists =
-				oc.includes(item) || oc.includes(item.replace(/'/g, '"'))
+                oc.includes(item) || oc.includes(item.replace(/'/g, '"')) || oc.includes(item.replace(/"/g, "'"));
 			if (exists) return
 
 			return item


### PR DESCRIPTION
## Contents of the oc variable

```
<script lang="ts">
import { supabaseClient } from '$lib/supabase';
import Footer from '$lib/components/layout/Footer.svelte';
import Header from '$lib/components/layout/Header.svelte';

const menus = [
```

## error

```
  Plugin: vite-plugin-svelte
  File: /src/lib/components/layout/Sidebar.svelte:4:7
   2 |  import Footer from "$lib/components/layout/Footer.svelte";
   3 |  import { supabaseClient } from "$lib/supabase";
   4 |  import Footer from "$lib/components/layout/Footer.svelte";
               ^
   5 |  import Header from "$lib/components/layout/Header.svelte";
 ```

Added quote conversion when checking existence

`import Footer from "$lib/components/layout/Footer.svelte"` → `import Footer from '$lib/components/layout/Footer.svelte'` add